### PR TITLE
Updates to fix blank page on second visit

### DIFF
--- a/force-app/main/default/aura/URL_CreateRecordCmp/URL_CreateRecordCmp.cmp
+++ b/force-app/main/default/aura/URL_CreateRecordCmp/URL_CreateRecordCmp.cmp
@@ -6,7 +6,7 @@
  * License: BSD 3-Clause License
  */
 -->
-<aura:component controller="URL_CreateRecordController" implements="lightning:isUrlAddressable,lightning:hasPageReference">
+<aura:component controller="URL_CreateRecordController" implements="lightning:isUrlAddressable">
 
     <aura:attribute name="showSpinner" type="Boolean" default="false"/>
     <aura:handler name="change" value="{!v.pageReference}" action="{!c.onPageReferenceChange}"/>

--- a/force-app/main/default/aura/URL_CreateRecordCmp/URL_CreateRecordCmp.cmp
+++ b/force-app/main/default/aura/URL_CreateRecordCmp/URL_CreateRecordCmp.cmp
@@ -6,10 +6,10 @@
  * License: BSD 3-Clause License
  */
 -->
-<aura:component controller="URL_CreateRecordController" implements="lightning:isUrlAddressable">
+<aura:component controller="URL_CreateRecordController" implements="lightning:isUrlAddressable,lightning:hasPageReference">
 
     <aura:attribute name="showSpinner" type="Boolean" default="false"/>
-
+    <aura:handler name="change" value="{!v.pageReference}" action="{!c.onPageReferenceChange}"/>
     <aura:handler name="init" value="{!this}" action="{!c.onInit}"/>
 
     <span class="{!v.showSpinner ? 'slds-show' : 'slds-hide'}">

--- a/force-app/main/default/aura/URL_CreateRecordCmp/URL_CreateRecordCmpController.js
+++ b/force-app/main/default/aura/URL_CreateRecordCmp/URL_CreateRecordCmpController.js
@@ -2,5 +2,8 @@
     // this method is called when component initializes
     onInit: function( component, event, helper ) {
         helper.handleShowCreateForm( component );
+    },
+    onPageReferenceChange: function( component, event, helper ) {
+        helper.handleShowCreateForm( component );
     }
 })

--- a/force-app/main/default/aura/URL_CreateRecordCmp/URL_CreateRecordCmpHelper.js
+++ b/force-app/main/default/aura/URL_CreateRecordCmp/URL_CreateRecordCmpHelper.js
@@ -25,7 +25,8 @@
         let urlParamMap = {
             'objectname' : '',      // object whose create form to display
             'recordtypeid' : '',    // record type for new record (optional)
-            'returnurl' : ''         // id of record where button was clicked
+            'recordid' : '',        // id of record where button was clicked
+            'actionurl' : ''        // location where hacking started
         };
 
         for ( let key in pageRef.state ) {
@@ -39,14 +40,22 @@
 
         Promise.resolve()
             .then( function() {
-                if ( !$A.util.isEmpty( urlParamMap.returnurl ) ) {
-                    // workaround for not being able to customize the cancel
-                    // behavior of the force:createRecord event. instead of
-                    // the user seeing a blank page, instead load in the background
-                    // the very record the user is viewing so when they click cancel
-                    // they are still on the same record.
-                    //helper.navigateToUrl( '/' + urlParamMap.recordid );
-                    helper.navigateToUrl( urlParamMap.returnurl );
+                // workaround for not being able to customize the cancel
+                // behavior of the force:createRecord event. instead of
+                // the user seeing a blank page, instead load in the background
+                // the very record the user is viewing so when they click cancel
+                // they are still on the same record.
+                let targetUrl;
+                if ( !$A.util.isEmpty( urlParamMap.recordid ) ) {
+                    targetUrl = '/' + urlParamMap.recordid;
+                }
+                else if ( !$A.util.isEmpty( urlParamMap.actionurl ) ) {
+                    targetUrl = urlParamMap.actionurl;
+                }
+
+                if ( !$A.util.isEmpty( targetUrl ) ) {
+                    
+                    helper.navigateToUrl( targetUrl );
                     // give the page some time to load the new url
                     // otherwise we end up firing the show create form
                     // event too early and the page navigation happens

--- a/force-app/main/default/aura/URL_CreateRecordCmp/URL_CreateRecordCmpHelper.js
+++ b/force-app/main/default/aura/URL_CreateRecordCmp/URL_CreateRecordCmpHelper.js
@@ -25,7 +25,7 @@
         let urlParamMap = {
             'objectname' : '',      // object whose create form to display
             'recordtypeid' : '',    // record type for new record (optional)
-            'recordid' : ''         // id of record where button was clicked
+            'returnurl' : ''         // id of record where button was clicked
         };
 
         for ( let key in pageRef.state ) {
@@ -39,13 +39,14 @@
 
         Promise.resolve()
             .then( function() {
-                if ( !$A.util.isEmpty( urlParamMap.recordid ) ) {
+                if ( !$A.util.isEmpty( urlParamMap.returnurl ) ) {
                     // workaround for not being able to customize the cancel
                     // behavior of the force:createRecord event. instead of
                     // the user seeing a blank page, instead load in the background
                     // the very record the user is viewing so when they click cancel
                     // they are still on the same record.
-                    helper.navigateToUrl( '/' + urlParamMap.recordid );
+                    //helper.navigateToUrl( '/' + urlParamMap.recordid );
+                    helper.navigateToUrl( urlParamMap.returnurl );
                     // give the page some time to load the new url
                     // otherwise we end up firing the show create form
                     // event too early and the page navigation happens


### PR DESCRIPTION
Also adding support for both recordid and actionurl parameters. This way you can use list views and other pages as trigger for your hacking url.